### PR TITLE
fix #35

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -37,7 +37,7 @@
   url: /help/
   side: left
   dropdown:
-  - title: Contact
+  - title: Contact (Login required)
     url: https://leeds.service-now.com/it?id=sc_cat_item&sys_id=7587b2530f675f00a82247ece1050eda
   - title: Documentation
     url: https://arc.leeds.ac.uk/
@@ -64,9 +64,9 @@
 - title: Self Service
   side: right
   dropdown:
-  - title: Log a Ticket
+  - title: Log a Ticket (Login required)
     url: https://leeds.service-now.com/it?id=sc_cat_item&sys_id=7587b2530f675f00a82247ece1050eda
     side: right
-  - title: Request an Account
+  - title: Request an Account (Login required)
     url: https://leeds.service-now.com/it?id=sc_cat_item&sys_id=4c002dd70f235f00a82247ece1050ebc
     side: right


### PR DESCRIPTION
fix #35 adds login required text for menu buttons

Looks OK on Ubuntu 20 Firefox, worth testing on other browsers before merging