### PR TITLE
Fix two minor ARIA issues

### DIFF
--- a/_includes/_breadcrumb.html
+++ b/_includes/_breadcrumb.html
@@ -4,12 +4,12 @@
 *
 {% endcomment %}
 
-<nav class="breadcrumbs" role="menubar" aria-label="breadcrumbs">
+<nav class="breadcrumbs" aria-label="breadcrumbs">
  <a href="{{ site.url }}{{ site.baseurl }}">{{ site.data.language.breadcrumb_start }}</a>
  {% assign crumbs = page.url | split: '/' %}
    {% for crumb in crumbs offset: 1 %}
     {% if forloop.last %}
-        <a class="current">{{ page.url | split: '/' | last }}</a>
+        <a class="current" aria-current="page">{{ page.url | split: '/' | last }}</a>
     {% else %}
         <a href="{{ site.url }}{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{{ crumb | replace:'-',' ' }}</a>
     {% endif %}


### PR DESCRIPTION
Removes the invalid role for the nav element, and explicitly sets the aria-current attribute for the link to the current page.

Former was a w3 validator error, latter just seems desirable.