### PR TITLE
adding more specific documentation linking on arc.leeds.ac.uk

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,12 +36,14 @@
   dropdown:
   - title: Contact (Login required)
     url: https://leeds.service-now.com/it?id=sc_cat_item&sys_id=7587b2530f675f00a82247ece1050eda
-  - title: Documentation
-    url: https://arcdocs.leeds.ac.uk/
   - title: FAQ
     url: /help/faq/
   - title: Bitesize Videos
     url: /help/videos/
+
+- title: Documentation
+  url: https://arcdocs.leeds.ac.uk/
+  side: left
 
 - title: Community
   url: /community/

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,5 +1,9 @@
 - menu_name: "Quick Links"
 
+- name: HPC Documentation
+  url: https://arcdocs.leeds.ac.uk/
+  title: Leeds HPC Documentation
+
 - name: "University of Leeds IT Services"
   url: "https://it.leeds.ac.uk/it"
   title: "IT Services Page"


### PR DESCRIPTION
aims to resolve #55 
added specific documentation menu link

also added link in the page footer