### PR TITLE
HPC1 wrong information: Fix #214

### DIFF
--- a/pages/training/training_courses/hpc1.md
+++ b/pages/training/training_courses/hpc1.md
@@ -4,11 +4,11 @@ permalink: "/training/courses/hpc1/"
 breadcrumb: true
 ---
 
-{% assign hpc1w = site.data.training_courses.widget | where:'code', page.code %}
+{% assign hpc1w = site.data.training_courses.widget | where:'code', 'HPC1' %}
 {% assign hpc1 = hpc1w[0] %}
 {% assign course = hpc1.content %}
 
-{% assign hpc0w = site.data.training_courses.widget | where:'code', 'HPC1' %}
+{% assign hpc0w = site.data.training_courses.widget | where:'code', 'HPC0' %}
 {% assign hpc0 = hpc0w[0] %}
 
 ### Booking for this course is through the IT Training Unit. [Click here to book]({{ course.booking }})


### PR DESCRIPTION
# Fix HPC1 content and links

A student sent me an email complaining about the link in the HPC1 [website](https://arc.leeds.ac.uk/training/courses/hpc1/).

As I documented in the issue #214, it seems that all HPC1 information in this page was switched by HPC0 information.
I believe this is a simple problem of variable definition, and fix it should (I hope) solve both info and links problems.