### PR TITLE
New training page

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -10,23 +10,112 @@
 
 - code: HPC0
   dates:
-    - 2024-03-20
+    - 2024-02-20
   tags:
-    - Tag1
-    - Tag2
+    - 1 Half Day
+    - Online
+
+- code: HPC1
+  dates:
+    - 2024-03-05
+    - 2024-03-12
+  tags:
+    - 2 Half Days
+    - Online
 
 - code: SWD2
   dates:
-    - 2024-04-15
-    - 2024-04-16
+    - 2024-03-21
   tags:
-    - Tag3
-    - Tag4
+    - 1 Day
+    - Online
+
+- code: SWD1a
+  dates:
+    - 2024-04-19
+    - 2024-04-26
+  tags:
+    - 2 Days
+    - Online
+
+- code: SWD1b
+  dates:
+    - 2024-05-13
+    - 2024-05-20
+  tags:
+    - 2 Days
+    - Online
+
+- code: HPC0
+  dates:
+    - 2024-06-19
+  tags:
+    - 1 Half Day
+    - In-Person
+
+- code: HPC1
+  dates:
+    - 2024-07-01
+  tags:
+    - 1 Day
+    - In-Person
+
+- code: SWD3
+  dates:
+    - 2024-07-25
+  tags:
+    - 1 Day
+    - In-Person
+
+- code: SWD1a
+  dates:
+    - 2024-08-08
+    - 2024-08-09
+  tags:
+    - 2 Days
+    - In-Person
+
+- code: HPC2
+  dates:
+    - 2024-09-10
+    - 2024-09-12
+  tags:
+    - 2 Half Days
+    - Online
+
+- code: DataVis
+  dates:
+    - 2024-09-25
+  tags:
+    - 1 Day
+    - In-Person
+
+- code: HPC0
+  dates:
+    - 2024-10-25
+  tags:
+    - 1 Half Day
+    - Online
+
+- code: HPC1
+  dates:
+    - 2024-11-04
+    - 2024-11-11
+  tags:
+    - 2 Half Days
+    - Online
 
 - code: SWD6
   dates:
-    - 2024-04-15
-    - 2024-04-16
+    - 2024-11-28
   tags:
-    - Tag3
-    - Tag4
+    - 1 Day
+    - Online
+
+- code: SWD1a
+  dates:
+    - 2024-12-03
+    - 2024-12-10
+  tags:
+    - 2 Days
+    - Online

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,36 @@
+# Data used to create the Upcoming Events under /training/ page
+# The layout for an event is:
+#
+# - code: Course_Code
+#   dates:
+#     - day 1 (format yyyy/mm/dd)
+#     - day 2 (if there is more than 1 day)
+#   location: Teams or Bluiding, Room
+#   tags:
+#     - Course_tag (some ideas: In-Person/Online, 1 half-day, 2 full days)
+
+- code: HPC0
+  dates:
+    - 2024-03-20
+  location: Venue A
+  tags:
+    - Tag1
+    - Tag2
+
+- code: SWD2
+  dates:
+    - 2024-04-15
+    - 2024-04-16
+  location: Venue B
+  tags:
+    - Tag3
+    - Tag4
+
+- code: SWD6
+  dates:
+    - 2024-04-15
+    - 2024-04-16
+  location: Venue B
+  tags:
+    - Tag3
+    - Tag4

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -5,14 +5,12 @@
 #   dates:
 #     - day 1 (format yyyy/mm/dd)
 #     - day 2 (if there is more than 1 day)
-#   location: Teams or Bluiding, Room
 #   tags:
 #     - Course_tag (some ideas: In-Person/Online, 1 half-day, 2 full days)
 
 - code: HPC0
   dates:
     - 2024-03-20
-  location: Venue A
   tags:
     - Tag1
     - Tag2
@@ -21,7 +19,6 @@
   dates:
     - 2024-04-15
     - 2024-04-16
-  location: Venue B
   tags:
     - Tag3
     - Tag4
@@ -30,7 +27,6 @@
   dates:
     - 2024-04-15
     - 2024-04-16
-  location: Venue B
   tags:
     - Tag3
     - Tag4

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,11 +13,6 @@
 - title: Training
   url: /training/
   side: left
-  dropdown:
-  - title: Calendar
-    url: /training/calendar/
-  - title: Courses
-    url: /training/courses/
 
 - title: About
   url: /about/

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -33,7 +33,6 @@
   <!-- Include General Information -->
   <div class="event-details">
     <h2>{{ course.title }}</h2>
-    {{ page.location }}
     <div class="tags">
       {% for tag in page.tags %}
         <span class="tag">{{ tag }}</span>

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -1,0 +1,46 @@
+{% comment %}
+
+  Generates the event banner.
+
+  All event information is retrieved from `_data/courses.yml`. This includes:
+    - Event Code
+    - Event Date(s)
+    - Event Location
+    - Event Tag(s)
+  All course content is retrieved from `_data/training_courses.yml` based in the event code:
+    - Course Title
+    - Course Description
+    - Course Link
+
+{% endcomment %}
+
+
+{% assign code = page.code %}
+{% assign courses = site.data.training_courses.widget | where:'code', code %}
+{% assign course = courses[0] %}
+
+<div class="event">
+
+  <!-- Include Blue Date Banner -->
+  <div class="event-date">
+    <div class="calendar-symbol"><i class="icon-calendar"></i></div>
+      {% for date in page.dates %}
+        <div class="date-text">{{ date | date: "%d %b" }}<br></div>
+      {% endfor %}
+       <div class="date-text">{{ page.dates[0] | date: "%Y" }}<br></div>
+  </div>
+
+  <!-- Include General Information -->
+  <div class="event-details">
+    <h2>{{ course.title }}</h2>
+    {{ page.location }}
+    <div class="tags">
+      {% for tag in page.tags %}
+        <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    {{ course.text }}
+    <a href="{{ course.url }}" class="read-more">Read More</a>
+  </div>
+
+</div>

--- a/_sass/_12_events-calendar.scss
+++ b/_sass/_12_events-calendar.scss
@@ -1,0 +1,52 @@
+.event {
+    display: flex;
+    background-color: #efefef;
+    margin-bottom: 20px;
+    padding: 10px;
+    border-radius: 8px;
+  }
+  
+.event-date {
+    flex: 0.5;
+    background-color: #0068b1;
+    color: #efefef;
+    padding: 10px;
+    text-align: center;
+    border-radius: 8px;
+  }
+
+.calendar-symbol {
+    font-size: 50px;
+  }
+  
+  .date-text {
+      font-size: 1.75em; /* Adjust the size of the month */
+    }
+    
+.event-details {
+    flex: 3;
+    padding: 10px;
+    margin-top: -60px;
+  }
+  
+.tags {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+  
+.tag {
+    display: inline-block;
+    background-color: #ccc;
+    padding: 5px;
+    margin-right: 5px;
+  }
+  
+.read-more {
+    display: inline-block;
+    // margin-top: 10px;
+    padding: 5px 10px;
+    background-color: #000;
+    color: #efefef;
+    text-decoration: none;
+    border-radius: 5px;
+  }

--- a/assets/css/styles_feeling_responsive.scss
+++ b/assets/css/styles_feeling_responsive.scss
@@ -48,4 +48,4 @@ sitemap:
 
 @import "11_syntax-highlighting.scss";
 
-@import "12_events-calendar"
+@import "12_events-calendar.scss"

--- a/assets/css/styles_feeling_responsive.scss
+++ b/assets/css/styles_feeling_responsive.scss
@@ -47,3 +47,5 @@ sitemap:
 {% endif %}
 
 @import "11_syntax-highlighting.scss";
+
+@import "12_events-calendar"

--- a/pages/training.md
+++ b/pages/training.md
@@ -1,29 +1,14 @@
 ---
-title: "Training"
+title: "Upcoming Events"
 permalink: "/training/"
 breadcrumb: true
 ---
 
-To see what courses are available and when:
-
-{% assign page_list = site.data.widgets.main | where: 'title', page.title %}
-
-{% assign page_data = page_list[0].subpages %}
-
-{% assign page_items = page_data | size %}
-
-{% assign page_nrows = page_items | divided_by: 4.0 | ceil %}
-
-{% assign col2 = 0 %}
-
-<div class="t60">
-  {% for row in (1..page_nrows) %}
-	   {% for col in (1..4) %}
-				{% assign col_data = page_data[col2] %}
-	      {% if col_data.title %}
-				   {% include _frontpage-widget.html widget=col_data  %}
-				{% endif %}
-				{% assign col2 = col2 | plus: 1 %}
-		{% endfor %}
-  {% endfor %}
-</div>		
+{% assign current_date = site.time | date: "%s" %}
+{% for event in site.data.events %}
+  {% assign event_date = event.dates[0] | date: "%s" %}
+  {% if event_date > current_date %}
+    {% assign page = event %}
+    {% include event.html %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Note: I did this on Grasi's laptop, so it is her name on commits, sorry about it.

This pull request creates a new training page.
How it works:

1. The `pages/training.md` was updated to retrieve information from `_data/events.yml`
2. For each event in `_data/events.yml` a banner will be created using the template available in `_includes/event.html` (and the style defined in `_sass/_12_events-calendar.scss`).
  - Note that the information under each event in `_data/events.yml` is minimum because I am using the course `code` to retrieve the course information from `_data/training_courses.yml`.
  - DataVis has no information under the `_data/training_courses.yml`, so one of the banners is empty, we can fix this later on.
3. The `pages/training.md` code verifies the date and display only future events. So in theory, it is not necessary delete old events. But I am not sure how this will be handled in future by the GH action.

This PR override the PR #223, so if this one is approved, the #223 should be deleted.